### PR TITLE
FIx Box2D import again

### DIFF
--- a/tools.py
+++ b/tools.py
@@ -32,11 +32,7 @@ from gettext import gettext as _
 from pygame.locals import *
 from helpers import *
 
-sys.path.append('lib/')
-# If your architecture is different, comment these lines and install
-# the modules in your system.
-sys.path.append('lib/Box2D-2.0.2b2-py2.7-linux-i686.egg')
-import Box2D as box2d
+import lib.Box2D as box2d
 
 from sugar3.activity import activity
 


### PR DESCRIPTION
Another import of Box2D was failing, reported in [SL4976](https://bugs.sugarlabs.org/ticket/4976#comment:6).

With this change, Physics-31 runs as an installed bundle on Fedora 25.

Signed-off-by: James Cameron <quozl@laptop.org>