### PR TITLE
check for identical vertices in is_line

### DIFF
--- a/myelements/tools_poly.py
+++ b/myelements/tools_poly.py
@@ -77,6 +77,9 @@ def is_line(vertices, tolerance=25.0):
     if len(vertices) <= 2:
         return True
 
+    if len(vertices) == 3 and vertices[0] == vertices[2]:
+        return True
+
     # Step 1: Points -> Vectors
     p_old = vertices[0]
     alphas = []


### PR DESCRIPTION
Drawing a closed polygon with two lines (draw a line, then close the polygon immediately with another line) would cause the activity to freeze.

```
Traceback (most recent call last):
  File "/usr/share/sugar/activities/Physics.activity/physics.py", line 140, in run
    self.currentTool.handleEvents(event)
  File "/usr/share/sugar/activities/Physics.activity/tools.py", line 122, in handleEvents
    return self.handleToolEvent(event)
  File "/usr/share/sugar/activities/Physics.activity/tools.py", line 440, in handleToolEvent
    friction=self.palette_data['friction'])
  File "/usr/share/sugar/activities/Physics.activity/tools.py", line 456, in constructor
    friction=friction)
  File "/usr/share/sugar/activities/Physics.activity/myelements/add_objects.py", line 454, in complexPoly
    friction), vertices
  File "/usr/share/sugar/activities/Physics.activity/myelements/add_objects.py", line 500, in convexPoly
    friction)
  File "/usr/share/sugar/activities/Physics.activity/myelements/add_objects.py", line 287, in poly
    friction)
  File "/usr/share/sugar/activities/Physics.activity/myelements/add_objects.py", line 314, in _poly
    polygonShape.vertices = vertices
  File "/usr/share/sugar/activities/Physics.activity/lib/box2d_64/Box2D.py", line 2998, in __set_vertices
    self.__set_vertices_internal() # calculates normals, centroid, etc.
  File "/usr/share/sugar/activities/Physics.activity/lib/box2d_64/Box2D.py", line 3035, in __set_vertices_internal
    return _Box2D.b2PolygonShape___set_vertices_internal(self, *args)
AssertionError: count >= 3
```

This adds an additional check to is_line. If the beginning and end vertices are the same in a polygon with 3 vertices, it's treated like a line.