### PR TITLE
Fix circles in centre of polygons

### DIFF
--- a/myelements/add_objects.py
+++ b/myelements/add_objects.py
@@ -415,7 +415,7 @@ class Add:
                 # Don't add a circle at the end
                 break
 
-            circleDef.localPosition = v2 / self.parent.ppm
+            circleShape.pos = v2 / self.parent.ppm
             body.CreateFixture(circleDef)
 
         # Return hard and soft reduced vertices


### PR DESCRIPTION
Many circles were added to the centre of a polygon.

Previously, the circles were between the transits, but with 02d4eef they
had moved to the centre of the polygon.

Fixes https://github.com/sugarlabs/physics/issues/47