### PR TITLE
Prevent groundBody from getting removed on clear_all

### DIFF
--- a/tools.py
+++ b/tools.py
@@ -98,7 +98,8 @@ class Tool(object):
                 elif event.action == 'clear_all':
                     # Get bodies and destroy them too
                     for body in self.game.world.world.bodies:
-                        self.game.world.world.DestroyBody(body)
+                        if body != self.game.world.world.groundBody:
+                            self.game.world.world.DestroyBody(body)
 
                     # Add ground, because we destroyed it before
                     self.game.world.add.ground()


### PR DESCRIPTION
Closes #27 
groundBody (this is not the ground on canvas) was getting removed on clear_all, leading to weird behaviours when joints were used on them afterwards.